### PR TITLE
Fix #708

### DIFF
--- a/lib/utilities/SWP_Compatibility.php
+++ b/lib/utilities/SWP_Compatibility.php
@@ -171,7 +171,7 @@ class SWP_Compatibility {
 		 *
 		 */
 		$dom = new DOMDocument();
-		$dom->loadHTML( $content );
+		$dom->loadHTML( $content, LIBXML_HTML_NODEFDTD );
 		$xpath = new DOMXPath( $dom );
 
 
@@ -210,7 +210,11 @@ class SWP_Compatibility {
 		 * modified content.
 		 *
 		 */
-		$content = $dom->saveHTML();
+		$html    = $dom->saveHTML();
+		$start   = strpos($html,'<body>') + 6;
+	 	$end     = strrpos($html,'</body>') - strlen($html);
+		$content = substr($html, $start, $end);
+		
 		libxml_use_internal_errors( $libxml_error_status );
 		libxml_clear_errors();
 


### PR DESCRIPTION
This fixes the creation of a doctype and html/body elements in the call of the_content.

* Since PHP 5.2.6 (and maybe earlier), saveHTML automatically creates doctypes and html/body elements
* Using LIBXML_HTML_NODEFDTD allows to not create the Doctype element
* Ideally, we should use LIBXML_HTML_NOIMPLIED as well. But it does not work with PHP 7 and is unstable at best
* So, it's better to strip html and body tags by hand