### PR TITLE
Add font-display:block;

### DIFF
--- a/lib/frontend-output/SWP_Header_Output.php
+++ b/lib/frontend-output/SWP_Header_Output.php
@@ -140,7 +140,7 @@ class SWP_Header_Output {
 		}
 
 		$style = '<style>@font-face {font-family: "sw-icon-font";src:url("' . SWP_PLUGIN_URL . '/assets/fonts/sw-icon-font.eot?ver=' . SWP_VERSION . '");src:url("' . SWP_PLUGIN_URL . '/assets/fonts/sw-icon-font.eot?ver=' . SWP_VERSION . '#iefix") format("embedded-opentype"),url("' . SWP_PLUGIN_URL . '/assets/fonts/sw-icon-font.woff?ver=' . SWP_VERSION . '") format("woff"),
-	url("' . SWP_PLUGIN_URL . '/assets/fonts/sw-icon-font.ttf?ver=' . SWP_VERSION . '") format("truetype"),url("' . SWP_PLUGIN_URL . '/assets/fonts/sw-icon-font.svg?ver=' . SWP_VERSION . '#1445203416") format("svg");font-weight: normal;font-style: normal;}</style>';
+	url("' . SWP_PLUGIN_URL . '/assets/fonts/sw-icon-font.ttf?ver=' . SWP_VERSION . '") format("truetype"),url("' . SWP_PLUGIN_URL . '/assets/fonts/sw-icon-font.svg?ver=' . SWP_VERSION . '#1445203416") format("svg");font-weight: normal;font-style: normal;font-display: block;}</style>';
 
 		if ( true === is_admin() ) {
 			echo $style;


### PR DESCRIPTION
This fixes the Ensure text remains visible during webfont load error in lighthouse https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools